### PR TITLE
feat: adding request duration and wasm memory used metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 publish = false
 authors = ["FastEdge Development Team"]


### PR DESCRIPTION
New metrics:
* request duration
* wasm memory used

Added new labels: executor (http, cdn) and reason (unknown, oop, timeout, other).