### PR TITLE
refactor: adjust logging levels, rename `FIXME` to `TODO`, and minor …

### DIFF
--- a/crates/http-service/src/executor/http.rs
+++ b/crates/http-service/src/executor/http.rs
@@ -36,7 +36,6 @@ where
         B: BodyExt + Send,
         <B as Body>::Data: Send,
     {
-        tracing::trace!("start execute");
         // Start timing for stats
         let stats_timer = StatsTimer::new(stats.clone());
 
@@ -349,7 +348,7 @@ mod tests {
 
             let component = self.loader().load_component(cfg.binary_id)?;
             let instance_pre = engine.component_instantiate_pre(&component)?;
-            tracing::info!("Added '{}' to cache", name);
+            tracing::debug!("Added '{}' to cache", name);
             Ok(HttpExecutorImpl::new(
                 instance_pre,
                 store_builder,

--- a/crates/http-service/src/executor/wasi_http.rs
+++ b/crates/http-service/src/executor/wasi_http.rs
@@ -38,7 +38,6 @@ where
         B: BodyExt + Send,
         <B as Body>::Data: Send,
     {
-        tracing::trace!("start execute");
         // Start timing for stats
         let stats_timer = StatsTimer::new(stats.clone());
 
@@ -61,7 +60,7 @@ where
             parts.uri = Uri::from_parts(uparts)?;
         }
 
-        //FIXME send streamed request body
+        //TODO: send streamed request body
         let body = body
             .collect()
             .await
@@ -105,7 +104,7 @@ where
         let mut store = store_builder.build(state).context("store build")?;
         let instance_pre = self.instance_pre.clone();
 
-        let request = hyper::Request::from_parts(parts, body);
+        let request = Request::from_parts(parts, body);
         let req = store
             .data_mut()
             .new_incoming_request(Scheme::Http, request)

--- a/crates/http-service/src/lib.rs
+++ b/crates/http-service/src/lib.rs
@@ -287,10 +287,12 @@ where
             }
             Ok(app_name) => app_name,
         };
+        let span = tracing::info_span!("handle", app = app_name.as_str());
+        let _enter = span.enter();
+
         // lookup for application config and binary_id
         tracing::debug!(
-            "Processing request for application '{}' on URL: {}",
-            app_name,
+            "Processing request URL: {}",
             request.uri()
         );
         let cfg = match self.context.lookup_by_name(&app_name).await {


### PR DESCRIPTION
…code cleanup

- Removed unused `tracing::trace` annotations in `http.rs` and `wasi_http.rs`.
- Changed a logging level from `info` to `debug` for cache addition messages.
- Updated comment from `FIXME` to `TODO` for clarity.
- Simplified request construction and applied consistent naming conventions.