### PR TITLE
refactor: remove default `ACCESS_CONTROL_ALLOW_ORIGIN` and `CACHE_CON…

### DIFF
--- a/crates/http-service/src/executor/http.rs
+++ b/crates/http-service/src/executor/http.rs
@@ -429,12 +429,7 @@ mod tests {
         let res = assert_ok!(http_service.handle_request("1".to_smolstr(), req).await);
         assert_eq!(StatusCode::OK, res.status());
         let headers = res.headers();
-        assert_eq!(4, headers.len());
-        assert_eq!(
-            "*",
-            assert_some!(headers.get("access-control-allow-origin"))
-        );
-        assert_eq!("no-store", assert_some!(headers.get("cache-control")));
+        assert_eq!(2, headers.len());
         assert_eq!("01", assert_some!(headers.get("RES_HEADER_01")));
         assert_eq!("02", assert_some!(headers.get("RES_HEADER_02")));
     }
@@ -484,12 +479,7 @@ mod tests {
         let res = assert_ok!(http_service.handle_request("2".to_smolstr(), req).await);
         assert_eq!(FASTEDGE_EXECUTION_TIMEOUT, res.status());
         let headers = res.headers();
-        assert_eq!(4, headers.len());
-        assert_eq!(
-            "*",
-            assert_some!(headers.get("access-control-allow-origin"))
-        );
-        assert_eq!("no-store", assert_some!(headers.get("cache-control")));
+        assert_eq!(2, headers.len());
         assert_eq!("03", assert_some!(headers.get("RES_HEADER_03")));
         let internal_status = assert_some!(headers.get(X_CDN_INTERNAL_STATUS))
             .to_str()
@@ -548,12 +538,7 @@ mod tests {
         let res = assert_ok!(http_service.handle_request("3".to_smolstr(), req).await);
         assert_eq!(FASTEDGE_OUT_OF_MEMORY, res.status());
         let headers = res.headers();
-        assert_eq!(4, headers.len());
-        assert_eq!(
-            "*",
-            assert_some!(headers.get("access-control-allow-origin"))
-        );
-        assert_eq!("no-store", assert_some!(headers.get("cache-control")));
+        assert_eq!(2, headers.len());
         assert_eq!("03", assert_some!(headers.get("RES_HEADER_03")));
         assert_eq!(
             INTERNAL_STATUS_OUT_OF_MEMORY.to_string(),
@@ -706,12 +691,7 @@ mod tests {
         let res = assert_ok!(http_service.handle_request("8".to_smolstr(), req).await);
         assert_eq!(StatusCode::OK, res.status());
         let headers = res.headers();
-        assert_eq!(4, headers.len());
-        assert_eq!(
-            "*",
-            assert_some!(headers.get("access-control-allow-origin"))
-        );
-        assert_eq!("no-store", assert_some!(headers.get("cache-control")));
+        assert_eq!(2, headers.len());
         assert_eq!("01", assert_some!(headers.get("RES_HEADER_01")));
         assert_eq!("02", assert_some!(headers.get("RES_HEADER_02")));
     }

--- a/crates/http-service/src/lib.rs
+++ b/crates/http-service/src/lib.rs
@@ -12,7 +12,6 @@ use anyhow::{Context, Error, Result, bail};
 use bytes::Bytes;
 use http::{
     HeaderMap, HeaderName, HeaderValue, StatusCode,
-    header::{ACCESS_CONTROL_ALLOW_ORIGIN, CACHE_CONTROL},
 };
 use http_backend::SERVER_NAME_HEADER;
 use http_body_util::{BodyExt, Empty, Full};
@@ -615,11 +614,6 @@ fn app_name_from_request(req: &hyper::Request<impl Body>) -> Result<AppName> {
 
 fn app_res_headers(app_cfg: App) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    headers.append(
-        ACCESS_CONTROL_ALLOW_ORIGIN,
-        HeaderValue::from_str("*").unwrap(),
-    );
-    headers.append(CACHE_CONTROL, HeaderValue::from_str("no-store").unwrap());
     /* if specified, add/remove/overwrite response headers */
     for (name, val) in app_cfg.rsp_headers {
         if !val.is_empty() {


### PR DESCRIPTION
…TROL` headers for cleaner response handling

- Eliminated setting default `ACCESS_CONTROL_ALLOW_ORIGIN` and `CACHE_CONTROL` headers in `app_res_headers` function.
- Updated tests to reflect the new header count and removed assertions for these headers.